### PR TITLE
fix(build): use python:3.11 instead of python:3.11-alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.4 (2023-04-03)
+
+- Switch Docker base image from `python:3.11-alpine` to `python:3.11` (fix [#6](https://github.com/dailymotion/demo-stream-urls-server/issues/6))
+
 # 0.0.3 (2023-03-24)
 
 - Fix IP detection when running on both player and server on the same machine (using [ifconfig.me](https://ifconfig.me))

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.11
 
 RUN mkdir /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "demo-stream-urls-server"
-version = "0.0.3"
+version = "0.0.4"
 
 requires-python = ">= 3.11"
 dependencies = [


### PR DESCRIPTION
fix an issue where some couldn't get `cffi` installed

```
building '_cffi_backend' extension
gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DFFI_BUILDING=1
-I/usr/include/ffi -I/usr/include/libffi -I/app/.venv/include
-I/usr/local/include/python3.11 -c c/_cffi_backend.c -o
build/temp.linux-aarch64-cpython-311/c/_cffi_backend.o
error: command 'gcc' failed: No such file or directory
```

ref https://github.com/dailymotion/demo-stream-urls-server/issues/6